### PR TITLE
Support Discord Documentation field names

### DIFF
--- a/example.py
+++ b/example.py
@@ -9,18 +9,33 @@ print("RPC connection successful.")
 time.sleep(5)
 start_time = time.time()
 while True:
+
+    # Supports using the format from the Discord Documentation
+    # Reference: https://discordapp.com/developers/docs/rich-presence/how-to#rich-presence-field-requirements
     activity = {
-            "state": "This is a sample state.",
-            "details": "This is a sample detail.",
-            "timestamps": {
-                "start": start_time
-            },
-            "assets": {
-                "small_text": "Text for small_image",
-                "small_image": "img_small",
-                "large_text": "Text for large_image",
-                "large_image": "img_large"
-            }
+        "state": "This is a sample state.",
+        "details": "This is a sample detail.",
+        "startTimestamp": start_time,
+        "smallImageText": "Text for small_image",
+        "smallImageKey": "img_small",
+        "largeImageText": "Text for large_image",
+        "largeImageKey": "img_large"
+    }
+
+    # Supports using RPC format
+    # Reference: https://github.com/discordapp/discord-rpc/blob/master/documentation/hard-mode.md
+    activity_rpc = {
+        "state": "This is a sample state.",
+        "details": "This is a sample detail.",
+        "timestamps": {
+            "start": start_time
+        },
+        "assets": {
+            "small_text": "Text for small_image",
+            "small_image": "img_small",
+            "large_text": "Text for large_image",
+            "large_image": "img_large"
         }
+    }
     rpc_obj.set_activity(activity)
     time.sleep(30)

--- a/rpc.py
+++ b/rpc.py
@@ -57,7 +57,8 @@ class DiscordIpcClient(metaclass=ABCMeta):
         pass
 
     def _do_handshake(self):
-        ret_op, ret_data = self.send_recv({'v': 1, 'client_id': self.client_id}, op=OP_HANDSHAKE)
+        ret_op, ret_data = self.send_recv(
+            {'v': 1, 'client_id': self.client_id}, op=OP_HANDSHAKE)
         # {'cmd': 'DISPATCH', 'data': {'v': 1, 'config': {...}}, 'evt': 'READY', 'nonce': None}
         if ret_op == OP_FRAME and ret_data['cmd'] == 'DISPATCH' and ret_data['evt'] == 'READY':
             return
@@ -129,10 +130,46 @@ class DiscordIpcClient(metaclass=ABCMeta):
 
     def set_activity(self, act):
         # act
+
+        activity_dict = act
+        # Checks if not using RPC Hard Mode formatting
+        if not act.keys() & {"timestamps", "assets", "party", "secrets"}:
+            # Fill in values. If a value doesn't exist, it is set as None
+            activity_dict = {
+                "state": act.get("state"),
+                "details": act.get("details"),
+                "timestamps": {
+                    "start": act.get("startTimestamp"),
+                    "end": act.get("endTimestamp")
+                },
+                "assets": {
+                    "large_image": act.get("largeImageKey"),
+                    "large_text": act.get("largeImageText"),
+                    "small_image": act.get("smallImageKey"),
+                    "small_text": act.get("smallImageText")
+                },
+                "party": {
+                    "id": act.get("partyId"),
+                    "size": [v for v in [act.get("partySize"), act.get("partyMax")] if v]
+                },
+                "secrets": {
+                    "join": act.get("joinSecret", None),
+                    "spectate": act.get("spectateSecret", None),
+                    "match": act.get("matchSecret", None)
+                }}
+            activity_reduced = {}
+            # Now remove all None values from the activity
+            for key, value in activity_dict.items(): # Remove unnecessary data
+                if isinstance(value, dict):
+                    activity_reduced[key] = {k: v for k, v in activity_dict[key].items() if v}
+                    if not activity_reduced[key]:
+                        del activity_reduced[key]
+
+            activity_dict = activity_reduced
         data = {
             'cmd': 'SET_ACTIVITY',
             'args': {'pid': os.getpid(),
-                     'activity': act},
+                     'activity': activity_dict},
             'nonce': str(uuid.uuid4())
         }
         self.send(data)

--- a/rpc.py
+++ b/rpc.py
@@ -160,6 +160,7 @@ class DiscordIpcClient(metaclass=ABCMeta):
             activity_reduced = {}
             # Now remove all None values from the activity
             for key, value in activity_dict.items(): # Remove unnecessary data
+                activity_reduced[key] = activity_dict[key]
                 if isinstance(value, dict):
                     activity_reduced[key] = {k: v for k, v in activity_dict[key].items() if v}
                     if not activity_reduced[key]:


### PR DESCRIPTION
This adds the ability to convert a dictionary with key names of the Discord Documentation field names into the RPC format.

PR from Issue #5  